### PR TITLE
TES-769: Popover Screen Improvements

### DIFF
--- a/app/popover.tsx
+++ b/app/popover.tsx
@@ -14,18 +14,22 @@ export default function CheckboxScreen() {
             <ThemedView style={styles.container}>
                 <Popover
                     from={(
-                        <Button title='Passing!'></Button>
+                        <Button accessibilityLabel='Passing!' title='Passing!'></Button>
                     )}>
-                    <ThemedText>This is the contents of the popover</ThemedText>
+                    <ThemedView>
+                        <ThemedText>This is the contents of the popover</ThemedText>
+                    </ThemedView>
                 </Popover>
             </ThemedView>
             <ThemedText style={styles.margin} accessibilityLabel="I fail due to no text">Case 1: The popover must have text.  This popover doesn't so it fails.</ThemedText>
             <ThemedView style={styles.container}>
                 <Popover
                     from={(
-                        <Button title='Failing!'></Button>
+                        <Button accessibilityLabel='Failing!' title='Failing!'></Button>
                     )}>
-                    <ThemedText></ThemedText>
+                    <ThemedView>
+                        <ThemedText></ThemedText>
+                    </ThemedView>
                 </Popover>
             </ThemedView>
         </ThemedView>

--- a/app/tabs/_layout.tsx
+++ b/app/tabs/_layout.tsx
@@ -37,7 +37,6 @@ export default function TabLayout() {
         name="tab2"
         options={{
           title: 'Tab 2',
-          tabBarAccessibilityLabel: "Hello?",
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
         }}
       />

--- a/app/tabs/tab2.tsx
+++ b/app/tabs/tab2.tsx
@@ -10,7 +10,7 @@ export default function TabTwoScreen() {
         <ThemedText style={styles.title}>Testing "tabs" rule</ThemedText>
       </ThemedView>
       <ThemedView style={styles.container}>
-        <ThemedText style={styles.margin}>This expo tab passes</ThemedText>
+        <ThemedText style={styles.margin}>Tab 2 passes</ThemedText>
       </ThemedView>
     </ThemedView>
   );


### PR DESCRIPTION
After a bunch of debugging and help from @jasonzhetan , we found that pre-tagging has a problem particularly in the `Text` case.  This was causing the popover tests to fail incorrectly.  So we wrapped them in a View for now.  Also made some minor changes to Tabs tests.