### PR TITLE
checkbox test cases

### DIFF
--- a/app/checkbox.tsx
+++ b/app/checkbox.tsx
@@ -22,7 +22,7 @@ export default function CheckboxScreen() {
                 <Checkbox value={isChecked} onValueChange={setIsChecked} />
             </ThemedView>
             <ThemedText style={styles.margin} accessibilityLabel="I fail due to duplicate label">Case 2: The accessibility label must be unique.  This text has the same accessibility label as the checkbox below so it fails the check</ThemedText>
-            <ThemedView style={styles.container}>
+            <ThemedView style={styles.container} accessibilityLabel="I fail due to duplicate label">
                 <Checkbox accessibilityLabel="I fail due to duplicate label" value={isChecked} onValueChange={setIsChecked} />
             </ThemedView>
         </ThemedView>

--- a/app/checkbox.tsx
+++ b/app/checkbox.tsx
@@ -21,7 +21,7 @@ export default function CheckboxScreen() {
             <ThemedView style={styles.container}>
                 <Checkbox value={isChecked} onValueChange={setIsChecked} />
             </ThemedView>
-            <ThemedText style={styles.margin} accessibilityLabel="I fail due to duplicate label">Case 2: The accessibility label must be unique.  This text has the same accessibility label as the checkbox below so it fails the check</ThemedText>
+            <ThemedText style={styles.margin}>Case 2: The accessibility label must be unique.  This text has the same accessibility label as the checkbox below so it fails the check</ThemedText>
             <ThemedView style={styles.container} accessibilityLabel="I fail due to duplicate label">
                 <Checkbox accessibilityLabel="I fail due to duplicate label" value={isChecked} onValueChange={setIsChecked} />
             </ThemedView>


### PR DESCRIPTION
ThemedText get their accessibility labels lumped together so it doesn't work for testing duplicate labels like this.  That is why this case was passing.  